### PR TITLE
docs(planning): add governance issue artifacts

### DIFF
--- a/docs/planning/governance/issues/G-01-introduce-prettier-toolchain.md
+++ b/docs/planning/governance/issues/G-01-introduce-prettier-toolchain.md
@@ -1,0 +1,46 @@
+## [Chore] Introduce Prettier formatting toolchain
+
+## Problem Statement
+
+The repository currently lacks a standardized formatter and a deterministic formatting command.
+
+Without a shared formatting toolchain, diffs become noisy, style drift accumulates, and reviews lose
+focus on behavior and invariants.
+
+---
+
+## Why This Matters Now
+
+Formatting should be stabilized early, before domain work begins, to avoid later churn and keep PRs
+readable.
+
+---
+
+## Success Criteria
+
+- [ ] Prettier is added as a dev dependency
+- [ ] A formatting command exists and is deterministic (`npm run format`)
+- [ ] A check command exists and fails on formatting drift (`npm run format:check`)
+- [ ] Prettier configuration files are committed (`.prettierrc`, `.prettierignore`)
+- [ ] No unrelated behavior changes introduced
+
+---
+
+## Scope & Constraints
+
+In scope:
+
+- Add Prettier + basic scripts
+- Add config + ignore files
+
+Out of scope:
+
+- CI enforcement (optional later)
+- Repo-wide reformat sweep (avoid churn unless necessary)
+
+---
+
+## Verification Notes
+
+- `npm run format` completes successfully
+- `npm run format:check` exits non-zero when formatting differs

--- a/docs/planning/governance/issues/G-02-add-branch-naming-reference.md
+++ b/docs/planning/governance/issues/G-02-add-branch-naming-reference.md
@@ -1,0 +1,44 @@
+## [Documentation] Add branch naming reference
+
+## Problem Statement
+
+Branch naming rules exist, but there is no single reference mapping approved branch names to current
+milestone issues.
+
+Without a quick reference, naming drift and cognitive overhead increase during milestone execution.
+
+---
+
+## Why This Matters Now
+
+This is a lightweight governance improvement that reinforces execution discipline and reduces
+friction as issue count grows.
+
+---
+
+## Success Criteria
+
+- [ ] `docs/governance/BRANCH_NAMING_REFERENCE.md` exists and is committed
+- [ ] The reference includes issue-to-branch mappings for the current milestone
+- [ ] Rules align with the repository branching strategy
+
+---
+
+## Scope & Constraints
+
+In scope:
+
+- Add the reference file under `docs/governance/`
+- Include branch naming rules and approved patterns
+
+Out of scope:
+
+- Automated enforcement (optional later)
+- Retroactive renaming of existing branches (unless necessary)
+
+---
+
+## Verification Notes
+
+- The file exists, is tracked, and is referenced when creating branches
+- Branch names created for issues match the reference


### PR DESCRIPTION
## docs(planning): add governance issue artifacts

Closes: (none)  
Milestone: (none)

---

## Summary

Track governance work items as canonical issue markdown files under `docs/planning/governance/issues/`.

This preserves the repository’s planning artifacts without misclassifying them as Milestone 0 issues.

---

## Changes

- Add:
  - `docs/planning/governance/issues/G-01-introduce-prettier-toolchain.md`
  - `docs/planning/governance/issues/G-02-add-branch-naming-reference.md`
- Remove the temporary `issues-extra/` bucket

---

## Verification

- Files are tracked in git and live in the governance planning namespace.
- Milestone issue directories remain unchanged.

---

## Architectural Layer Check

Documentation/planning only. No runtime changes.

## Project Knowledge Sync Check

No frozen docs changed. No workspace sync required.