### PR TITLE
governance(scripts): improve issue creation script label inference

### DIFF
--- a/docs/planning/governance/issues/G-03-improve-create-issues-script-label-inference.md
+++ b/docs/planning/governance/issues/G-03-improve-create-issues-script-label-inference.md
@@ -1,0 +1,46 @@
+## [Governance] Improve issue creation script label inference
+
+## Problem Statement
+
+The `scripts/create_issues.sh` automation does not fully align with the canonical label taxonomy.
+
+Without consistent inference rules, issues created via the script may miss required `type:` labels or omit useful `area:` labels, causing taxonomy drift and extra manual cleanup.
+
+---
+
+## Why This Matters Now
+
+We are actively using `create_issues.sh` to create canonical work items.
+
+The script must stay aligned with `docs/governance/LABELS.md` so governance remains consistent and low-friction.
+
+---
+
+## Success Criteria
+
+- [ ] Issues with `[Chore]` prefix are created with `type: governance`
+- [ ] Tooling-related issue titles infer `area: tooling` when applicable
+- [ ] Existing inference behavior remains unchanged for other issue types and areas
+
+---
+
+## Scope & Constraints
+
+In scope:
+- Update `scripts/create_issues.sh` label inference:
+  - map `[Chore]` → `type: governance`
+  - infer `area: tooling` for formatter/lint/tooling work
+
+Out of scope:
+- Changing label taxonomy
+- Enforcing labels via CI
+- Any changes to issue templates
+
+---
+
+## Verification Notes
+
+- Run script in dry-run mode and confirm inferred labels are correct:
+  - `DRY_RUN=1 ./scripts/create_issues.sh --milestone \"...\" --dir \"...\"`
+- Create at least one issue for real and confirm labels appear on GitHub:
+  - `DRY_RUN=0 ...`

--- a/scripts/create_issues.sh
+++ b/scripts/create_issues.sh
@@ -110,6 +110,7 @@ infer_type_label() {
       decision) echo "type: decision" ;;
       feature) echo "type: feature" ;;
       refactor) echo "type: refactor" ;;
+      chore) echo "type: governance" ;;
       documentation|docs|doc) echo "type: documentation" ;;
       spike) echo "type: spike" ;;
       governance) echo "type: governance" ;;
@@ -124,6 +125,11 @@ infer_area_label() {
   local title="$1"
   local lower
   lower="$(echo "$title" | tr '[:upper:]' '[:lower:]')"
+
+  # tooling
+  if echo "$lower" | grep -Eq "\btooling\b|prettier|\bformat\b|formatting|\blint\b|\beslint\b"; then
+    echo "area: tooling"; return
+  fi
 
   # governance / repo administration
   if echo "$lower" | grep -Eq "\bgovernance\b|branch protection|pull request template|pr template|\btemplates?\b|\blabels?\b|\bmilestones?\b|\bgithub\b|\brepo\b"; then


### PR DESCRIPTION
## governance(scripts): improve issue creation script label inference

Closes: #22

---

## Summary

Align `scripts/create_issues.sh` with the canonical label taxonomy defined in `docs/governance/LABELS.md`.

This ensures automation remains consistent with governance rules.

---

## Changes

- Map `[Chore]` prefix to `type: governance`
- Infer `area: tooling` for tooling-related work items
- Add canonical governance issue artifact (G-03)

---

## Verification

- `DRY_RUN=1 ./scripts/create_issues.sh --milestone "…" --dir "…"` shows correct inferred labels
- Script behavior remains unchanged for existing issue types

---

## Architectural Layer Check

Repository automation only. No runtime changes.

---

## Project Knowledge Sync Check

No frozen architecture or scope documents modified.
