### PR TITLE
chore(tsconfig): remove deprecated baseUrl for TS 7 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
       "@lib/*": ["./app/lib/*"],


### PR DESCRIPTION
## What changed
- Updated [tsconfig.json](c:/GIT/LABAREDA/once-more-with-feeling/labareda-menu-manager/tsconfig.json) to address the `baseUrl` deprecation warning.

## Why
- `baseUrl` is deprecated for future TypeScript versions.
- This keeps the project forward-compatible without changing runtime behavior.

## Invariant protected
- Existing alias-based import resolution remains stable.

## Verification
- `npm run typecheck`
- `npm run build` (optional but recommended)
- `npm run check` (full repo gate)

## Intentionally excluded
- No architecture/domain logic changes.
- No refactor of import paths beyond config-level compatibility.
