### PR TITLE
docs: align governance docs with current repo state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture Reference
 
 > Status: Frozen as of Milestone 0. Changes to this document require an architectural decision
-> recorded in `DECISIONS.md`. Last implementation-alignment review: 2026-03-18.
+> recorded in `DECISIONS.md`. Last implementation-alignment review: 2026-04-14.
 
 Labareda Menu Manager Architecture
 
@@ -119,7 +119,7 @@ Import constraints:
 - `app/api/**/route.ts` must not import Prisma.
 - `app/lib/domain/**` must not import Prisma.
 - Prisma imports are restricted to persistence and DB adapter files (`app/lib/persistence/**` and
-  `app/lib/db.ts`).
+  `app/lib/db/prisma-client.ts`).
 
 This is enforced by convention and review ritual; violations are treated as architectural defects.
 

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -1,7 +1,7 @@
 # Milestones
 
 Status: Active. This document defines capability boundaries for the project. Changes to milestone
-structure require architectural review and may require a new ADR. Last reviewed: 2026-03-18.
+structure require architectural review and may require a new ADR. Last reviewed: 2026-04-14.
 
 ---
 
@@ -44,7 +44,7 @@ Closes when:
 
 - Next.js App Router is initialized
 - TypeScript and ESLint are configured
-- Prisma + SQLite are configured
+- Prisma + Postgres (Neon-targeted) are configured
 - Initial migration runs successfully
 - Governance documents exist and are coherent
 - Branch protection and PR workflow are enforced

--- a/PROJECT_TREE.md
+++ b/PROJECT_TREE.md
@@ -15,6 +15,8 @@
 |   `-- pre-commit
 |-- app
 |   |-- lib
+|   |   |-- db
+|   |   |   `-- prisma-client.ts
 |   |   |-- domain
 |   |   |   |-- __tests__
 |   |   |   |   |-- domain-error-taxonomy.test.ts
@@ -37,11 +39,10 @@
 |   |   |   `-- Audience.ts
 |   |   |-- errors
 |   |   |   `-- NotImplementedError.ts
-|   |   |-- persistence
-|   |   |   `-- menu-version
-|   |   |       |-- mapStatus.ts
-|   |   |       `-- PrismaMenuVersionRepository.ts
-|   |   `-- db.ts
+|   |   `-- persistence
+|   |       `-- menu-version
+|   |           |-- mapStatus.ts
+|   |           `-- PrismaMenuVersionRepository.ts
 |   |-- globals.css
 |   |-- layout.tsx
 |   |-- page.tsx
@@ -67,8 +68,8 @@
 |       |-- milestone-1
 |       |   |-- issues
 |       |   |   |-- M1-01-introduce-menuversion-schema.md
-|       |   |   |-- M1-02-introduce-menuversion-domain-model-and-repository-boundary.md
 |       |   |   |-- M1-02.5-introduce-vitest-domain-testing-harness.md
+|       |   |   |-- M1-02-introduce-menuversion-domain-model-and-repository-boundary.md
 |       |   |   |-- M1-03-enforce-single-draft-invariant.md
 |       |   |   |-- M1-04-implement-audience-based-draft-workspace-read.md
 |       |   |   |-- M1-05-ensure-initial-draft-workspace-exists-idempotently.md
@@ -82,9 +83,7 @@
 |               `-- P1-04-create-labels-and-milestones.md
 |-- prisma
 |   |-- migrations
-|   |   |-- 20260212173944_smoke_test
-|   |   |   `-- migration.sql
-|   |   |-- 20260223212023_add_menuversion_model
+|   |   |-- 20260412000000_postgres_baseline
 |   |   |   `-- migration.sql
 |   |   `-- migration_lock.toml
 |   `-- schema.prisma
@@ -103,8 +102,8 @@
 |-- eslint.config.mjs
 |-- MILESTONES.md
 |-- next.config.ts
-|-- package-lock.json
 |-- package.json
+|-- package-lock.json
 |-- prisma.config.ts
 |-- PROJECT_TREE.md
 |-- README.md
@@ -117,8 +116,8 @@
 
 ## Summary
 
-- **Total Files**: 81
-- **Total Directories**: 30
+- **Total Files**: 80
+- **Total Directories**: 23
 - **Exclusion Source**: `.gitignore`
 - **Excluded Highlights**: `.git`, `node_modules`, `.next`, `.temp`, `.agents`, `.vscode`,
   `coverage`, `out`, `build`, `generated`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Labareda Menu Manager
 
-Last updated: 2026-03-18  
+Last updated: 2026-04-14  
 Current package version: `0.2.0`
 
 Labareda Menu Manager is a single-restaurant menu management system built as a full-stack web

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Status: Active execution phase. Last reviewed: 2026-03-18.
+Status: Active execution phase. Last reviewed: 2026-04-14.
 
 This document defines the ordered progression of capability delivery. It translates milestone
 definitions into execution sequence and current focus.


### PR DESCRIPTION
## What changed

This PR aligns the long-lived governance and repository-state documents with the current implementation state.

- Updates review timestamps across `ARCHITECTURE.md`, `MILESTONES.md`, `README.md`, and `ROADMAP.md`.
- Corrects the architecture reference for the Prisma client boundary from `app/lib/db.ts` to `app/lib/db/prisma-client.ts`.
- Updates milestone language from SQLite to Postgres / Neon-targeted persistence.
- Refreshes `PROJECT_TREE.md` to match the current app, persistence, Prisma migration, and file-count structure.

## Capability contract

After this PR, the repo governance docs can reliably describe the current architecture and persistence layout without pointing contributors at stale paths or the previous SQLite-era setup.

## Invariant protected

The documentation now preserves the architecture invariant that Prisma access is isolated to the persistence / DB adapter boundary, specifically `app/lib/persistence/**` and `app/lib/db/prisma-client.ts`.

## Intentionally excluded

This is a documentation-only alignment PR. It does not change runtime behavior, domain invariants, persistence logic, schema files, or generated Prisma client behavior.

## Verification

- `npm run check`