### PR TITLE
feat(schema): add category model

### DIFF
--- a/prisma/migrations/20260513002753_add_category_model/migration.sql
+++ b/prisma/migrations/20260513002753_add_category_model/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Category" (
+    "id" TEXT NOT NULL,
+    "menuVersionId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "position" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Category_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Category_position_menuVersionId_key" ON "Category"("position", "menuVersionId");
+
+-- AddForeignKey
+ALTER TABLE "Category" ADD CONSTRAINT "Category_menuVersionId_fkey" FOREIGN KEY ("menuVersionId") REFERENCES "MenuVersion"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,8 +14,21 @@ enum MenuVersionStatus {
 }
 
 model MenuVersion {
-  id        String            @id @default(cuid())
-  status    MenuVersionStatus @default(DRAFT)
-  createdAt DateTime          @default(now())
-  updatedAt DateTime          @updatedAt
+  id         String            @id @default(cuid())
+  status     MenuVersionStatus @default(DRAFT)
+  categories Category[]
+  createdAt  DateTime          @default(now())
+  updatedAt  DateTime          @updatedAt
+}
+
+model Category {
+  id            String      @id @default(cuid())
+  menuVersion   MenuVersion @relation(fields: [menuVersionId], references: [id])
+  menuVersionId String
+  displayName   String
+  position      Int
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+
+  @@unique([position, menuVersionId])
 }


### PR DESCRIPTION
## Summary

Adds the Milestone 2 category persistence shape required by issue #87.

This introduces `Category` as a Prisma model owned by `MenuVersion`, with a `position` field and a uniqueness constraint for category ordering per menu version.

Closes #87

## Scope

In scope:

- Add `Category` to `prisma/schema.prisma`
- Link `Category` to existing `MenuVersion`
- Add `displayName`, `position`, and timestamps
- Add unique `(position, menuVersionId)` constraint
- Add Prisma migration for the category table

Out of scope:

- Domain category model
- Repository boundary
- Ordering invariant enforcement
- Category create/move/delete behavior
- Items
- UI and route handlers

## Verification

- `npm run db:validate`
- `npm run db:generate`
- `npm run check`

Note: `npm run db:reset` was intentionally not run because `prisma.config.ts` uses `DATABASE_URL_UNPOOLED`; migration application should be verified against an explicitly disposable database or CI environment.