### PR TITLE
feat(category): add category domain repository boundary

### DIFF
--- a/app/lib/domain/__tests__/CategoryRepository.contract.test.ts
+++ b/app/lib/domain/__tests__/CategoryRepository.contract.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'vitest';
+
+import type { Category } from '@domain/category/Category';
+import type { CreateCategoryInput } from '@domain/category/CreateCategoryInput';
+import type { CategoryRepository } from '@domain/category/repositories/CategoryRepository';
+
+class FakeCategoryRepository implements CategoryRepository {
+  private readonly categories: Category[];
+
+  constructor(categories: Category[]) {
+    this.categories = categories.map((category) => ({ ...category }));
+  }
+
+  async createCategory(input: CreateCategoryInput): Promise<Category> {
+    const newCategory = {
+      id: `category-${input.menuVersionId}-${input.position}`,
+      ...input,
+    };
+
+    this.categories.push(newCategory);
+
+    return { ...newCategory };
+  }
+
+  async listByMenuVersionId(menuVersionId: string): Promise<Category[]> {
+    const categoriesByMenuVersionId = this.categories
+      .filter((category) => category.menuVersionId === menuVersionId)
+      .sort((a, b) => a.position - b.position);
+
+    return categoriesByMenuVersionId.map((category) => ({ ...category }));
+  }
+}
+
+describe('CategoryRepository contract', () => {
+  test('creates and returns a category from domain input', async () => {
+    const fakeRepo = new FakeCategoryRepository([]);
+
+    const input: CreateCategoryInput = {
+      menuVersionId: '001',
+      displayName: 'Category A',
+      position: 0,
+    };
+
+    const newCategory: Category = await fakeRepo.createCategory(input);
+
+    expect(newCategory.id).toBeTypeOf('string');
+    expect(newCategory.menuVersionId).toBe(input.menuVersionId);
+    expect(newCategory.displayName).toBe(input.displayName);
+    expect(newCategory.position).toBe(input.position);
+  });
+
+  test('lists only categories for the requested menu version', async () => {
+    const initialCategories: Category[] = [
+      { id: 'category-001-0', menuVersionId: '001', displayName: 'Category A', position: 0 },
+      { id: 'category-002-0', menuVersionId: '002', displayName: 'Category B', position: 0 },
+    ];
+
+    const fakeRepo = new FakeCategoryRepository(initialCategories);
+
+    const categories: Category[] = await fakeRepo.listByMenuVersionId('001');
+
+    expect(categories).toHaveLength(1);
+    expect(categories[0].id).toBe('category-001-0');
+    expect(categories.every((category) => category.menuVersionId === '001')).toBe(true);
+  });
+
+  test('returns categories ordered by position', async () => {
+    const initialCategories: Category[] = [
+      { id: 'category-002-0', menuVersionId: '001', displayName: 'Category B', position: 1 },
+      { id: 'category-003-0', menuVersionId: '001', displayName: 'Category C', position: 2 },
+      { id: 'category-001-0', menuVersionId: '001', displayName: 'Category A', position: 0 },
+    ];
+
+    const fakeRepo = new FakeCategoryRepository(initialCategories);
+
+    const categories: Category[] = await fakeRepo.listByMenuVersionId('001');
+
+    expect(categories).toHaveLength(3);
+    expect(categories[0].position).toBe(0);
+    expect(categories[1].position).toBe(1);
+    expect(categories[2].position).toBe(2);
+  });
+});

--- a/app/lib/domain/category/Category.ts
+++ b/app/lib/domain/category/Category.ts
@@ -1,0 +1,6 @@
+export interface Category {
+  id: string;
+  menuVersionId: string;
+  displayName: string;
+  position: number;
+}

--- a/app/lib/domain/category/CreateCategoryInput.ts
+++ b/app/lib/domain/category/CreateCategoryInput.ts
@@ -1,0 +1,5 @@
+export interface CreateCategoryInput {
+  menuVersionId: string;
+  displayName: string;
+  position: number;
+}

--- a/app/lib/domain/category/repositories/CategoryRepository.ts
+++ b/app/lib/domain/category/repositories/CategoryRepository.ts
@@ -1,0 +1,7 @@
+import type { Category } from '@domain/category/Category';
+import type { CreateCategoryInput } from '@domain/category/CreateCategoryInput';
+
+export interface CategoryRepository {
+  createCategory(input: CreateCategoryInput): Promise<Category>;
+  listByMenuVersionId(menuVersionId: string): Promise<Category[]>;
+}

--- a/app/lib/domain/menu-version/MenuVersion.ts
+++ b/app/lib/domain/menu-version/MenuVersion.ts
@@ -1,4 +1,4 @@
-import { MenuVersionStatus } from '@domain/menu-version/MenuVersionStatus';
+import type { MenuVersionStatus } from '@domain/menu-version/MenuVersionStatus';
 
 export interface MenuVersion {
   id: string;

--- a/app/lib/persistence/category/PrismaCategoryRepository.ts
+++ b/app/lib/persistence/category/PrismaCategoryRepository.ts
@@ -1,0 +1,34 @@
+import { getPrismaClient } from '@lib/db/prisma-client';
+
+import type { Category } from '@domain/category/Category';
+import type { CreateCategoryInput } from '@domain/category/CreateCategoryInput';
+import type { CategoryRepository } from '@domain/category/repositories/CategoryRepository';
+
+const db = getPrismaClient();
+
+export class PrismaCategoryRepository implements CategoryRepository {
+  async listByMenuVersionId(menuVersionId: string): Promise<Category[]> {
+    const records = await db.category.findMany({
+      where: { menuVersionId },
+      orderBy: { position: 'asc' },
+    });
+
+    return records.map((record) => ({
+      id: record.id,
+      menuVersionId: record.menuVersionId,
+      displayName: record.displayName,
+      position: record.position,
+    }));
+  }
+
+  async createCategory(input: CreateCategoryInput): Promise<Category> {
+    const record = await db.category.create({ data: input });
+
+    return {
+      id: record.id,
+      menuVersionId: record.menuVersionId,
+      displayName: record.displayName,
+      position: record.position,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add the category domain shape and create input contract
- Add a domain-owned `CategoryRepository` boundary for category creation and menu-version-scoped reads
- Add a Prisma category repository adapter that maps persistence records into domain entities
- Add DB-free contract tests for category creation, scoped reads, and position ordering

## Verification

- `npm run check`

## Scope

Closes #88 
It does not add category create/move/delete behavior, ordering invariant enforcement, UI, or route handlers.