### PR TITLE
feat(category): add category ordering invariant checker

### DIFF
--- a/app/lib/domain/__tests__/requireContiguousCategoryOrder.test.ts
+++ b/app/lib/domain/__tests__/requireContiguousCategoryOrder.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'vitest';
+
+import { CategoryOrderingInvariantViolationError } from '@domain/category/CategoryOrderingInvariantViolationError';
+import { requireContiguousCategoryOrder } from '@domain/category/requireContiguousCategoryOrder';
+
+import type { Category } from '@domain/category/Category';
+
+function expectCategoryOrderingViolation(
+  err: unknown,
+  expected: {
+    menuVersionIds: string[];
+    categoryCount: number;
+    positions: number[];
+    duplicatePositions: number[];
+    missingPositions: number[];
+  }
+) {
+  expect(err).toBeInstanceOf(CategoryOrderingInvariantViolationError);
+
+  if (!(err instanceof CategoryOrderingInvariantViolationError)) {
+    throw new Error('expected CategoryOrderingInvariantViolationError');
+  }
+
+  expect(err.code).toBe('ORDERING_INVARIANT_VIOLATION');
+  expect(err.meta.menuVersionIds).toHaveLength(expected.menuVersionIds.length);
+
+  for (const menuVersionId of expected.menuVersionIds) {
+    expect(err.meta.menuVersionIds).toContain(menuVersionId);
+  }
+
+  expect(err.meta.categoryCount).toBe(expected.categoryCount);
+  expect(err.meta.positions).toStrictEqual(expected.positions);
+  expect(err.meta.duplicatePositions).toStrictEqual(expected.duplicatePositions);
+  expect(err.meta.missingPositions).toStrictEqual(expected.missingPositions);
+}
+
+describe('requireContiguousCategoryOrder', () => {
+  test('returns categories when positions are 0-based contiguous and unique', () => {
+    const categories: Category[] = [
+      { id: 'category-1', menuVersionId: 'menu-version-1', position: 0, displayName: 'Category 1' },
+      { id: 'category-2', menuVersionId: 'menu-version-1', position: 1, displayName: 'Category 2' },
+      { id: 'category-3', menuVersionId: 'menu-version-1', position: 2, displayName: 'Category 3' },
+    ];
+
+    const result = requireContiguousCategoryOrder(categories);
+
+    expect(result).toBe(categories);
+  });
+
+  test('throws when category order starts above 0', () => {
+    const categories: Category[] = [
+      { id: 'category-1', menuVersionId: 'menu-version-1', position: 1, displayName: 'Category 1' },
+      { id: 'category-2', menuVersionId: 'menu-version-1', position: 2, displayName: 'Category 2' },
+      { id: 'category-3', menuVersionId: 'menu-version-1', position: 3, displayName: 'Category 3' },
+    ];
+
+    try {
+      requireContiguousCategoryOrder(categories);
+      throw new Error('expected function to throw');
+    } catch (err) {
+      expectCategoryOrderingViolation(err, {
+        menuVersionIds: ['menu-version-1'],
+        categoryCount: 3,
+        positions: [1, 2, 3],
+        duplicatePositions: [],
+        missingPositions: [0],
+      });
+    }
+  });
+
+  test('throws when a category position is duplicated', () => {
+    const categories: Category[] = [
+      { id: 'category-1', menuVersionId: 'menu-version-1', position: 0, displayName: 'Category 1' },
+      { id: 'category-2', menuVersionId: 'menu-version-1', position: 1, displayName: 'Category 2' },
+      { id: 'category-3', menuVersionId: 'menu-version-1', position: 1, displayName: 'Category 3' },
+    ];
+
+    try {
+      requireContiguousCategoryOrder(categories);
+      throw new Error('expected function to throw');
+    } catch (err) {
+      expectCategoryOrderingViolation(err, {
+        menuVersionIds: ['menu-version-1'],
+        categoryCount: 3,
+        positions: [0, 1, 1],
+        duplicatePositions: [1],
+        missingPositions: [2],
+      });
+    }
+  });
+
+  test('throws when a category position is skipped', () => {
+    const categories: Category[] = [
+      { id: 'category-1', menuVersionId: 'menu-version-1', position: 0, displayName: 'Category 1' },
+      { id: 'category-2', menuVersionId: 'menu-version-1', position: 2, displayName: 'Category 2' },
+      { id: 'category-3', menuVersionId: 'menu-version-1', position: 3, displayName: 'Category 3' },
+    ];
+
+    try {
+      requireContiguousCategoryOrder(categories);
+      throw new Error('expected function to throw');
+    } catch (err) {
+      expectCategoryOrderingViolation(err, {
+        menuVersionIds: ['menu-version-1'],
+        categoryCount: 3,
+        positions: [0, 2, 3],
+        duplicatePositions: [],
+        missingPositions: [1],
+      });
+    }
+  });
+
+  test('throws when categories from multiple menu versions are mixed', () => {
+    const categories: Category[] = [
+      { id: 'category-1', menuVersionId: 'menu-version-1', position: 0, displayName: 'Category 1' },
+      { id: 'category-2', menuVersionId: 'menu-version-1', position: 1, displayName: 'Category 2' },
+      { id: 'category-3', menuVersionId: 'menu-version-2', position: 2, displayName: 'Category 3' },
+    ];
+
+    try {
+      requireContiguousCategoryOrder(categories);
+      throw new Error('expected function to throw');
+    } catch (err) {
+      expectCategoryOrderingViolation(err, {
+        menuVersionIds: ['menu-version-1', 'menu-version-2'],
+        categoryCount: 3,
+        positions: [0, 1, 2],
+        duplicatePositions: [],
+        missingPositions: [],
+      });
+    }
+  });
+
+  test('returns an empty category list when no categories exist', () => {
+    const categories: Category[] = [];
+
+    const result = requireContiguousCategoryOrder(categories);
+
+    expect(result).toBe(categories);
+  });
+});

--- a/app/lib/domain/category/CategoryOrderingInvariantViolationError.ts
+++ b/app/lib/domain/category/CategoryOrderingInvariantViolationError.ts
@@ -1,0 +1,21 @@
+import { DomainError } from '@domain/errors/DomainError';
+
+type CategoryOrderingInvariantViolationMeta = {
+  menuVersionIds: string[];
+  categoryCount: number;
+  positions: number[];
+  duplicatePositions: number[];
+  missingPositions: number[];
+};
+
+export class CategoryOrderingInvariantViolationError extends DomainError<CategoryOrderingInvariantViolationMeta> {
+  constructor(meta: CategoryOrderingInvariantViolationMeta) {
+    super(
+      'ORDERING_INVARIANT_VIOLATION',
+      'Expected category positions to be 0-based, contiguous, and unique for a single MenuVersion.',
+      meta
+    );
+
+    this.name = 'CategoryOrderingInvariantViolationError';
+  }
+}

--- a/app/lib/domain/category/requireContiguousCategoryOrder.ts
+++ b/app/lib/domain/category/requireContiguousCategoryOrder.ts
@@ -1,0 +1,50 @@
+import { CategoryOrderingInvariantViolationError } from '@domain/category/CategoryOrderingInvariantViolationError';
+
+import type { Category } from '@domain/category/Category';
+
+export function requireContiguousCategoryOrder(categories: Category[]): Category[] {
+  const menuVersionIds = [...new Set(categories.map((category) => category.menuVersionId))];
+  const positions = categories.map((category) => category.position);
+  const duplicatePositions = findDuplicatePositions(positions);
+  const missingPositions = findMissingPositions(positions, categories.length);
+
+  if (menuVersionIds.length > 1 || duplicatePositions.length > 0 || missingPositions.length > 0) {
+    throw new CategoryOrderingInvariantViolationError({
+      menuVersionIds,
+      categoryCount: categories.length,
+      positions,
+      duplicatePositions,
+      missingPositions,
+    });
+  }
+
+  return categories;
+}
+
+function findDuplicatePositions(positions: number[]): number[] {
+  const seenPositions = new Set<number>();
+  const duplicatePositions = new Set<number>();
+
+  for (const position of positions) {
+    if (seenPositions.has(position)) {
+      duplicatePositions.add(position);
+    }
+
+    seenPositions.add(position);
+  }
+
+  return [...duplicatePositions];
+}
+
+function findMissingPositions(positions: number[], categoryCount: number): number[] {
+  const actualPositions = new Set(positions);
+  const missingPositions: number[] = [];
+
+  for (let expectedPosition = 0; expectedPosition < categoryCount; expectedPosition++) {
+    if (!actualPositions.has(expectedPosition)) {
+      missingPositions.push(expectedPosition);
+    }
+  }
+
+  return missingPositions;
+}


### PR DESCRIPTION
## Summary

- Add a pure domain checker for category ordering within a single `MenuVersion`
- Add a category-specific domain error for ordering invariant violations
- Cover valid ordering plus start-above-0, duplicate, skipped, mixed-version, and empty-list cases

## Verification

- `npm run check`

## Invariant Protected

Category positions for one `MenuVersion` must be 0-based, contiguous, and unique.

## Out of Scope

- Mutating category order
- Auto-repairing corrupted order
- Persistence integration

Closes #89 