### PR TITLE
docs: align milestone 2 planning and governance state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture Reference
 
 > Status: Frozen as of Milestone 0. Changes to this document require an architectural decision
-> recorded in `DECISIONS.md`. Last implementation-alignment review: 2026-04-14.
+> recorded in `DECISIONS.md`. Last implementation-alignment review: 2026-05-29.
 
 Labareda Menu Manager Architecture
 
@@ -33,7 +33,8 @@ database.
 
 # 1A. Current Implementation Snapshot
 
-As of 2026-03-18, the implemented slice is Milestone 1 only.
+As of 2026-05-29, the implemented slice is the draft workspace foundation plus early category domain
+and persistence behavior.
 
 Implemented:
 
@@ -41,14 +42,21 @@ Implemented:
 - Domain invariant enforcement for single-draft cardinality
 - Domain bootstrap operation (`ensureDraftWorkspace`)
 - Domain read operation (`getDraftWorkspace`) for `adminEdit`
+- Category schema linked to `MenuVersion`
+- Category domain model and repository boundary
+- Prisma-backed category repository adapter
+- Category ordering invariant enforcement
+- Category creation in the draft workspace
 
 Not yet implemented:
 
-- Category and item domain behavior
+- Item domain behavior
+- Category update, move, or delete-empty behavior
 - Publish flow
 - Public read path
 - Authentication boundary
 - Route handlers for menu operations
+- Admin or public menu UI workflows
 
 This section clarifies implementation status only; it does not change architecture policy.
 
@@ -58,13 +66,16 @@ This section clarifies implementation status only; it does not change architectu
 
 The system follows a strict layered architecture.
 
-```
+```text
 UI (App Router Pages + Components)
-        ↓
+        |
+        v
 Route Handlers (HTTP boundary)
-        ↓
+        |
+        v
 Domain Layer (`lib/`)
-        ↓
+        |
+        v
 Persistence Layer (Prisma + Database)
 ```
 
@@ -127,7 +138,7 @@ This is enforced by convention and review ritual; violations are treated as arch
 
 # 3. Core Domain Model
 
-## 3.1 MenuVersion (Workspace Model — B1)
+## 3.1 MenuVersion (Workspace Model - B1)
 
 MenuVersion represents a workspace.
 
@@ -157,24 +168,30 @@ No historical browsing is modeled.
 
 Belongs to exactly one MenuVersion.
 
-Fields (conceptual):
+Implemented fields:
 
 - id
 - menuVersionId
-- name
-- description (optional)
-- sortOrder
-- isVisible
+- displayName
+- position
+
+Target fields not yet implemented:
+
+- description (optional), if retained by future product design
+- isVisible, if category visibility remains part of the final public-menu model
 
 Invariants:
 
-- sortOrder is 0-based, contiguous, unique per MenuVersion
-- name uniqueness scope defined per MenuVersion
-- Deletion allowed only if category contains no items
+- position is 0-based, contiguous, unique per MenuVersion
+- displayName is normalized before creation
+- displayName is unique per draft MenuVersion for category creation
+- Deletion allowed only if category contains no items once items exist
 
 ---
 
 ## 3.3 Item
+
+Target architecture. Not implemented yet.
 
 Belongs to exactly one Category and one MenuVersion.
 
@@ -199,6 +216,8 @@ Invariants:
 
 # 4. Publish Flow
 
+Target architecture. Not implemented yet.
+
 Publish operation must be atomic.
 
 Steps:
@@ -213,6 +232,9 @@ No partial publish states may be visible externally.
 ---
 
 # 4A. MenuVersion State Transition Diagram
+
+Target architecture for publish behavior. Only the statuses and draft workspace foundation are
+implemented today.
 
 MenuVersion statuses form a simple directed state machine.
 
@@ -257,6 +279,8 @@ REPLACED exists to preserve referential integrity and auditability without expos
 
 # 5. Audience-Based Domain Reads
 
+Target architecture. Current implementation supports `adminEdit` draft reads only.
+
 Domain read operations are audience-aware.
 
 Audiences:
@@ -290,9 +314,35 @@ All visibility filtering logic belongs in the domain layer.
 
 # 5A. Request Lifecycle Walkthroughs
 
-This section describes end-to-end request flow across layers.
+This section describes end-to-end request flow across layers. Only the domain-level category
+creation flow is implemented today; UI, route handlers, item behavior, publish behavior, and
+category movement remain target architecture.
 
-## 5A.1 Example: Create Item (Admin)
+## 5A.1 Current Example: Create Category in Draft Workspace
+
+Goal: Append a category to the DRAFT workspace while preserving category ordering invariants.
+
+Implemented domain flow:
+
+1. Caller
+   - Supplies an audience, category repository, menu-version repository, and display name.
+   - Does not decide draft lifecycle or ordering rules.
+
+2. Domain
+   - Normalizes `displayName` by trimming whitespace.
+   - Rejects empty names with `InvalidCategoryDisplayNameError`.
+   - Resolves the single draft workspace through `getDraftWorkspace`.
+   - Reads existing draft categories through `CategoryRepository.listByMenuVersionId`.
+   - Enforces category ordering through `requireContiguousCategoryOrder`.
+   - Rejects duplicate normalized display names.
+   - Calls `CategoryRepository.createCategory` with the next contiguous `position`.
+
+3. Persistence
+   - Stores the requested category and maps the record back to the domain `Category` shape.
+
+## 5A.2 Target Example: Create Item (Admin)
+
+Not implemented yet.
 
 Goal: Create a new item in a category within the DRAFT workspace.
 
@@ -321,16 +371,18 @@ Flow:
 
 5. Route Handler
    - Maps domain result:
-     - success → 201 JSON
-     - domain validation error → 400
-     - not found → 404
-     - invariant/corruption error → 409 or 500 depending on classification
+     - success -> 201 JSON
+     - domain validation error -> 400
+     - not found -> 404
+     - invariant/corruption error -> 409 or 500 depending on classification
 
 6. UI
    - Updates UI state.
    - Shows explicit error message if returned.
 
-## 5A.2 Example: Publish Draft
+## 5A.3 Target Example: Publish Draft
+
+Not implemented yet.
 
 Goal: Make the draft menu live and create a fresh draft seeded from it.
 
@@ -348,8 +400,8 @@ Flow:
      - ordering invariants for categories and items
      - referential integrity (items match category MenuVersion)
    - Runs atomic publish transaction:
-     - demote current PUBLISHED → REPLACED (if exists)
-     - promote DRAFT → PUBLISHED
+     - demote current PUBLISHED -> REPLACED (if exists)
+     - promote DRAFT -> PUBLISHED
      - create new DRAFT
      - seed new DRAFT with categories/items copied from new PUBLISHED
    - Returns success or explicit domain error.
@@ -366,7 +418,9 @@ Notes:
 - Seeding the new draft is operationally required for owner-friendly editing.
 - The system does not expose prior versions through UI; REPLACED is internal.
 
-## 5A.3 Example: Move Category Up (Ordering Swap)
+## 5A.4 Target Example: Move Category Up (Ordering Swap)
+
+Not implemented yet.
 
 Goal: Move a category up by one position within the DRAFT workspace while preserving ordering
 invariants.
@@ -374,7 +428,7 @@ invariants.
 Flow:
 
 1. UI (Admin)
-   - Admin clicks “Move up” on a category.
+   - Admin clicks "Move up" on a category.
 
 2. Route Handler
    - Validates transport concerns (categoryId present).
@@ -382,13 +436,13 @@ Flow:
 
 3. Domain (lib/)
    - Resolves DRAFT MenuVersion.
-   - Loads the target category and its neighbor (sortOrder - 1) within the same MenuVersion.
+   - Loads the target category and its neighbor (`position - 1`) within the same MenuVersion.
    - Applies rules:
      - If category is already at the top boundary, operation is a no-op.
-     - Otherwise, swap sortOrder with the immediate neighbor.
+     - Otherwise, swap `position` with the immediate neighbor.
    - Performs swap atomically in a single transaction.
    - Ensures postconditions:
-     - sortOrder values remain contiguous, unique, and cover 0..N-1.
+     - `position` values remain contiguous, unique, and cover 0..N-1.
    - Returns success or explicit corruption/invariant error.
 
 4. Persistence (Prisma)
@@ -396,9 +450,9 @@ Flow:
 
 5. Route Handler
    - Maps domain result:
-     - success → 200
-     - not found → 404
-     - corrupted ordering → 409
+     - success -> 200
+     - not found -> 404
+     - corrupted ordering -> 409
 
 6. UI
    - Re-renders list using the returned ordering.
@@ -408,9 +462,22 @@ Flow:
 
 # 5B. Error Taxonomy and HTTP Mapping
 
+Target architecture for route handlers and transport mapping. Current implementation has a
+domain-owned `DomainError` base class plus concrete domain errors; HTTP mapping is not implemented
+yet.
+
 The system distinguishes error classes to keep behavior predictable and debuggable.
 
 ## 5B.1 Domain Error Classes
+
+Current implemented domain errors:
+
+- `DraftInvariantViolationError`
+- `UnsupportedAudienceError`
+- `CategoryOrderingInvariantViolationError`
+- `InvalidCategoryDisplayNameError`
+
+The classes below are target transport classifications, not current class names.
 
 ### ValidationError
 
@@ -475,13 +542,13 @@ Examples:
 
 Route handlers translate domain errors into HTTP responses.
 
-- ValidationError → 400
-- NotFoundError → 404
-- ConflictError → 409
-- CorruptionError → 409 (or 500 if treating as internal fault; choose one policy and keep it
+- ValidationError -> 400
+- NotFoundError -> 404
+- ConflictError -> 409
+- CorruptionError -> 409 (or 500 if treating as internal fault; choose one policy and keep it
   consistent)
-- AuthError → 401 (or 403 depending on auth mechanism)
-- UnexpectedError → 500
+- AuthError -> 401 (or 403 depending on auth mechanism)
+- UnexpectedError -> 500
 
 ## 5B.3 Error Payload Contract (Transport)
 
@@ -499,8 +566,15 @@ The UI should render `message` directly and avoid interpreting error causes beyo
 
 ## 5B.4 Reserved Error Code Appendix
 
-This appendix defines stable, reusable error codes. These codes form part of the transport contract
-and must not be changed casually.
+This appendix defines target transport error codes. These are not all implemented yet, and they must
+be reconciled with current domain codes before route handlers expose them as an HTTP contract.
+
+Current implemented domain codes:
+
+- `DRAFT_INVARIANT_VIOLATION`
+- `UNSUPPORTED_AUDIENCE`
+- `ORDERING_INVARIANT_VIOLATION`
+- `INVALID_CATEGORY_DISPLAY_NAME`
 
 ### Category Errors
 
@@ -560,13 +634,16 @@ Ordering is explicit and deterministic.
 
 Categories:
 
-- sortOrder per MenuVersion
+- position per MenuVersion
 - Modified only via domain operations
+- Current implementation validates 0-based, contiguous, unique category positions and appends new
+  draft categories at the next position.
 
 Items:
 
 - sortOrder per Category
 - Modified only via domain operations
+- Target architecture. Not implemented yet.
 
 Ordering changes must be atomic.
 
@@ -575,6 +652,8 @@ Corrupted ordering (gaps or duplicates) results in domain error.
 ---
 
 # 7. Visibility Model
+
+Target architecture. Not implemented yet.
 
 Visibility and publish state are orthogonal.
 
@@ -591,6 +670,8 @@ Public display rule:
 
 # 8. Authentication Boundary
 
+Target architecture. Not implemented yet.
+
 Authentication protects:
 
 - All admin routes
@@ -604,6 +685,10 @@ Authentication is minimal and does not model roles or multi-user behavior.
 ---
 
 # 9. Data Integrity and Transactions
+
+Target architecture for mutation flows that can expose intermediate invalid states. Current category
+creation relies on domain ordering validation and the database uniqueness constraint, but the
+broader transaction policy is not fully implemented yet.
 
 Operations that modify:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,39 @@ behavior changes in a way that affects users or contributors.
 
 ## Unreleased
 
-- No unreleased changes yet after `0.2.0`.
+### Added
+
+- Category persistence linked to `MenuVersion`, including `displayName`, `position`, and a unique
+  `(position, menuVersionId)` constraint.
+- Category domain model, repository boundary, and Prisma-backed repository adapter.
+- DB-free category repository contract coverage.
+- Category ordering invariant enforcement:
+  - `requireContiguousCategoryOrder()`
+  - `CategoryOrderingInvariantViolationError` (`ORDERING_INVARIANT_VIOLATION`)
+- Draft category creation operation:
+  - `createCategoryInDraftWorkspace()`
+  - `InvalidCategoryDisplayNameError` (`INVALID_CATEGORY_DISPLAY_NAME`)
+  - trimmed display-name normalization
+  - duplicate display-name rejection within the draft workspace
+  - fail-loud behavior when existing category order is corrupt
+- Milestone 2 hardening plan for concurrent category appends and category creation postcondition
+  checks.
+- ADR-011 for Postgres singleton-DRAFT enforcement.
+- ADR-012 recording `position` as the canonical category ordering field name.
+
+### Changed
+
+- Quality gate script renamed from `npm run check` to `npm run verify`.
+- TypeScript path aliases ordered by specificity for more stable auto-import behavior.
+- Root governance docs aligned to the current implementation state and remaining Milestone 2 work.
+
+### Known Deferrals
+
+- ADR-011 implementation follow-ups remain open:
+  - Postgres partial unique index for singleton DRAFT
+  - repository create-conflict readback
+  - deterministic singleton-DRAFT bootstrap tests
+- Milestone 2 still excludes category move, delete-empty, and proof closure work.
 
 ---
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -39,6 +39,8 @@ All PRs that introduce or rely on an ADR must link to it.
 | ADR-008 | Domain error taxonomy and invariant failure model       | Accepted | 2026-02-24 | —          |
 | ADR-009 | Concurrency-safe DRAFT bootstrap enforcement model      | Accepted | 2026-03-09 | —          |
 | ADR-010 | Prisma-Neon connection target alignment contract        | Accepted | 2026-04-12 | ADR-009\*  |
+| ADR-011 | Postgres singleton-DRAFT enforcement model              | Accepted | 2026-05-29 | ADR-009    |
+| ADR-012 | Category ordering field name is position                | Accepted | 2026-05-29 | ADR-003\*  |
 
 ---
 
@@ -530,3 +532,136 @@ cross-target drift.
 - Configuration now has a hard invariant between pooled and unpooled Neon hosts
 - Local setup documentation must describe `.env.local` and both URL roles
 - Invalid or mismatched DB URL configuration now fails during startup/CLI bootstrap
+
+---
+
+## ADR-011 - Postgres singleton-DRAFT enforcement model
+
+Status: Accepted Date: 2026-05-29 Supersedes: ADR-009
+
+### Decision
+
+Enforce the singleton DRAFT workspace invariant in Postgres with a partial unique index:
+
+```sql
+CREATE UNIQUE INDEX "MenuVersion_single_draft_key"
+ON "MenuVersion" ("status")
+WHERE "status" = 'DRAFT';
+```
+
+Repository bootstrap behavior must reconcile only the expected create-conflict case: if concurrent
+empty-database callers race to create the first DRAFT and the database rejects the second insert,
+the repository reads and returns the singleton DRAFT. Other failures continue to surface.
+
+The domain invariant posture remains unchanged: non-empty corruption, including zero DRAFT rows or
+multiple DRAFT rows observed during reads, fails loudly.
+
+### Context
+
+ADR-009 selected a hybrid singleton-DRAFT enforcement model, but its concrete follow-ups were
+SQLite-specific. The project now targets Postgres through Neon, so the storage-level guardrail needs
+to be expressed in Postgres terms.
+
+The current implementation has `ensureDraftWorkspace()` and a `createDraft()` repository method, but
+the schema does not yet include a singleton-DRAFT database constraint and the repository does not
+yet reconcile create conflicts.
+
+### Options Considered
+
+- Leave singleton-DRAFT enforcement in domain code only
+- Add a full unique constraint on `MenuVersion.status`
+- Add a Postgres partial unique index for `status = 'DRAFT'` plus repository conflict readback
+
+### Criteria
+
+- Preserve the domain invariant that exactly one DRAFT exists
+- Allow multiple PUBLISHED or REPLACED lifecycle states only where architecture permits future
+  transitions
+- Keep concurrent bootstrap deterministic
+- Avoid silently repairing already-corrupt non-empty states
+- Use database-native enforcement compatible with the current Postgres target
+
+### Outcome
+
+Postgres partial unique index plus repository conflict readback was selected.
+
+This preserves ADR-009's hybrid model while replacing the SQLite-specific implementation detail with
+a Postgres-compatible constraint. It protects storage from duplicate DRAFT rows and keeps bootstrap
+idempotent under expected contention.
+
+### Consequences
+
+- A migration must add the Postgres partial unique index on `MenuVersion(status)` where status is
+  DRAFT.
+- `PrismaMenuVersionRepository.createDraft()` must translate the unique-conflict path into a read of
+  the singleton DRAFT.
+- The repository must not reconcile zero-DRAFT or multiple-DRAFT corruption during normal reads.
+- Tests must cover sequential bootstrap, create-conflict readback, and failure propagation.
+- ADR-009 remains historical context but is superseded for concrete storage enforcement.
+
+### Follow-ups
+
+- [ ] Add Postgres migration for `MenuVersion_single_draft_key`
+- [ ] Implement create-conflict readback in `PrismaMenuVersionRepository.createDraft()`
+- [ ] Add deterministic tests for singleton-DRAFT bootstrap behavior
+
+---
+
+## ADR-012 - Category ordering field name is position
+
+Status: Accepted Date: 2026-05-29 Supersedes: ADR-003 (partial)
+
+### Decision
+
+Use `position` as the canonical field name for category ordering in the domain model, repository
+contracts, Prisma schema, and tests.
+
+The ordering invariant from ADR-003 remains unchanged: category positions are explicit integers,
+0-based, contiguous, and unique within one `MenuVersion`; ordering changes are owned by domain
+operations.
+
+### Context
+
+ADR-003 used `sortOrder` as the conceptual field name for category and item ordering. The
+implemented category model uses `position` consistently:
+
+- Prisma `Category.position`
+- domain `Category.position`
+- `CreateCategoryInput.position`
+- `CategoryRepository` ordering by `position`
+- `requireContiguousCategoryOrder`
+- draft category creation appending at `draftCategories.length`
+
+The architecture reference now uses `position` for implemented category behavior. Leaving ADR-003 as
+the only naming record would make the accepted decision log conflict with the actual category
+contract.
+
+### Options Considered
+
+- Rename implementation from `position` back to `sortOrder`
+- Edit ADR-003 in place
+- Add a partial superseding ADR that records `position` for categories while preserving the ordering
+  invariant
+
+### Criteria
+
+- Preserve append-only ADR governance
+- Match the current implemented contract
+- Keep terminology short and stable across schema, domain, persistence, and tests
+- Avoid changing the ordering invariant while resolving the naming drift
+
+### Outcome
+
+`position` is the canonical category ordering field name.
+
+ADR-003 still defines the ordering model and invariant. ADR-012 supersedes ADR-003 only where
+ADR-003 names the category ordering field `sortOrder`.
+
+### Consequences
+
+- New category code and docs must use `position`, not `sortOrder`.
+- Existing category schema and tests remain aligned with the accepted naming decision.
+- Future item work may either use `position` for consistency or record a separate decision if item
+  ordering needs different terminology.
+- References to `sortOrder` in target item architecture remain conceptual until item implementation
+  begins.

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -1,7 +1,7 @@
 # Milestones
 
 Status: Active. This document defines capability boundaries for the project. Changes to milestone
-structure require architectural review and may require a new ADR. Last reviewed: 2026-04-14.
+structure require architectural review and may require a new ADR. Last reviewed: 2026-05-29.
 
 ---
 
@@ -81,9 +81,15 @@ Verification artifact:
 
 - `docs/planning/milestone-1/issues/M1-06-integration-verification-and-milestone-1-proof.md`
 
+Implementation note:
+
+- ADR-011 records storage-level Postgres hardening for the singleton-DRAFT invariant. That follow-up
+  does not reopen Milestone 1, but it should be completed before relying on the draft workspace
+  invariant for broader mutation flows.
+
 ---
 
-## Milestone 2 - Categories Ordered Within Draft
+## Milestone 2 - Categories Ordered Within Draft (Active)
 
 Capability unlocked: Categories can be created and ordered within the draft workspace.
 
@@ -93,6 +99,26 @@ Closes when:
 - Category ordering invariants are enforced (0-based, contiguous, unique per version)
 - Create, move up/down, and delete-empty-category operations work in draft
 - Ordering corruption results in explicit domain error
+
+Implemented so far:
+
+- Category schema linked to `MenuVersion`
+- Category domain model and repository boundary
+- Prisma-backed category repository adapter
+- Category ordering invariant checker
+- Draft category creation operation
+
+Remaining before closure:
+
+- Move category up/down within draft workspace
+- Delete empty category and close ordering gap
+- Milestone 2 proof artifact
+- Documentation updates that record closure evidence
+
+Deferred hardening:
+
+- Concurrent category append protection
+- Category creation postcondition checks
 
 Explicitly excludes:
 

--- a/PROJECT_TREE.md
+++ b/PROJECT_TREE.md
@@ -19,11 +19,23 @@
 |   |   |   `-- prisma-client.ts
 |   |   |-- domain
 |   |   |   |-- __tests__
+|   |   |   |   |-- CategoryRepository.contract.test.ts
+|   |   |   |   |-- createCategoryInDraftWorkspace.test.ts
 |   |   |   |   |-- domain-error-taxonomy.test.ts
 |   |   |   |   |-- ensureDraftWorkspace.test.ts
 |   |   |   |   |-- getDraftWorkspace.test.ts
+|   |   |   |   |-- requireContiguousCategoryOrder.test.ts
 |   |   |   |   |-- requireSingleDraftMenuVersion.test.ts
 |   |   |   |   `-- vitest-harness.test.ts
+|   |   |   |-- category
+|   |   |   |   |-- repositories
+|   |   |   |   |   `-- CategoryRepository.ts
+|   |   |   |   |-- Category.ts
+|   |   |   |   |-- CategoryOrderingInvariantViolationError.ts
+|   |   |   |   |-- CreateCategoryInput.ts
+|   |   |   |   |-- InvalidCategoryDisplayNameError.ts
+|   |   |   |   |-- createCategoryInDraftWorkspace.ts
+|   |   |   |   `-- requireContiguousCategoryOrder.ts
 |   |   |   |-- errors
 |   |   |   |   |-- DomainError.ts
 |   |   |   |   `-- UnsupportedAudienceError.ts
@@ -31,18 +43,20 @@
 |   |   |   |   |-- repositories
 |   |   |   |   |   `-- MenuVersionRepository.ts
 |   |   |   |   |-- DraftInvariantViolationError.ts
-|   |   |   |   |-- ensureDraftWorkspace.ts
-|   |   |   |   |-- getDraftWorkspace.ts
 |   |   |   |   |-- MenuVersion.ts
 |   |   |   |   |-- MenuVersionStatus.ts
+|   |   |   |   |-- ensureDraftWorkspace.ts
+|   |   |   |   |-- getDraftWorkspace.ts
 |   |   |   |   `-- requireSingleDraftMenuVersion.ts
 |   |   |   `-- Audience.ts
 |   |   |-- errors
 |   |   |   `-- NotImplementedError.ts
 |   |   `-- persistence
+|   |       |-- category
+|   |       |   `-- PrismaCategoryRepository.ts
 |   |       `-- menu-version
-|   |           |-- mapStatus.ts
-|   |           `-- PrismaMenuVersionRepository.ts
+|   |           |-- PrismaMenuVersionRepository.ts
+|   |           `-- mapStatus.ts
 |   |-- globals.css
 |   |-- layout.tsx
 |   |-- page.tsx
@@ -75,6 +89,16 @@
 |       |   |   |-- M1-05-ensure-initial-draft-workspace-exists-idempotently.md
 |       |   |   `-- M1-06-integration-verification-and-milestone-1-proof.md
 |       |   `-- ISSUE_MAP.md
+|       |-- milestone-2
+|       |   |-- issues
+|       |   |   |-- M2-05-move-category-up-down-within-draft-workspace.md
+|       |   |   |-- M2-06-delete-empty-category-and-close-ordering-gap.md
+|       |   |   |-- M2-07-integration-verification-and-milestone-2-proof.md
+|       |   |   |-- M2-H01-harden-concurrent-category-appends.md
+|       |   |   |-- M2-H02-add-category-creation-postcondition-checks.md
+|       |   |   `-- M2-P01-implement-postgres-singleton-draft-enforcement.md
+|       |   |-- ISSUE_MAP.md
+|       |   `-- M2_HARDENING.md
 |       `-- phase-1
 |           `-- issues
 |               |-- P1-01-foundational-governance-documents.md
@@ -85,13 +109,15 @@
 |   |-- migrations
 |   |   |-- 20260412000000_postgres_baseline
 |   |   |   `-- migration.sql
+|   |   |-- 20260513002753_add_category_model
+|   |   |   `-- migration.sql
 |   |   `-- migration_lock.toml
 |   `-- schema.prisma
 |-- scripts
+|   |-- README.md
 |   |-- create_issues.sh
 |   |-- create_milestones.sh
-|   |-- proof-m1.integration.test.ts
-|   `-- README.md
+|   `-- proof-m1.integration.test.ts
 |-- .env.example
 |-- .gitignore
 |-- .prettierignore
@@ -116,8 +142,8 @@
 
 ## Summary
 
-- **Total Files**: 80
-- **Total Directories**: 23
+- **Total Files**: 100
+- **Total Directories**: 36
 - **Exclusion Source**: `.gitignore`
 - **Excluded Highlights**: `.git`, `node_modules`, `.next`, `.temp`, `.agents`, `.vscode`,
   `coverage`, `out`, `build`, `generated`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Labareda Menu Manager
 
-Last updated: 2026-04-14  
+Last updated: 2026-05-29
+
 Current package version: `0.2.0`
 
 Labareda Menu Manager is a single-restaurant menu management system built as a full-stack web
@@ -14,7 +15,7 @@ first-class concerns.
 
 ## Current Capability (Implemented)
 
-Milestone 1 is complete.
+Milestone 1 is complete. Milestone 2 is active.
 
 The system can now reliably:
 
@@ -22,17 +23,29 @@ The system can now reliably:
 - enforce the invariant "exactly one `DRAFT` exists" in the domain layer
 - retrieve the draft workspace for `adminEdit` audience deterministically
 - fail loudly on corruption through domain errors (`DRAFT_INVARIANT_VIOLATION`)
+- represent categories owned by a `MenuVersion`
+- expose a domain-level category repository boundary without Prisma in domain code
+- validate category positions as 0-based, contiguous, and unique per `MenuVersion`
+- create a category in the draft workspace at the next contiguous position
+- reject empty or duplicate draft category display names through domain errors
 
 Implemented domain operations:
 
 - `ensureDraftWorkspace(repo)`
 - `getDraftWorkspace(audience, repo)`
 - `requireSingleDraftMenuVersion(versions)`
+- `requireContiguousCategoryOrder(categories)`
+- `createCategoryInDraftWorkspace(audience, categoryRepository, menuVersionRepository, displayName)`
 
 Implemented proof workflow:
 
 - `npm run proof:m1`
 - `scripts/proof-m1.integration.test.ts`
+
+Current known hardening:
+
+- ADR-011 records the Postgres singleton-DRAFT database constraint and repository conflict-readback
+  behavior that still need implementation.
 
 ---
 
@@ -67,7 +80,7 @@ Clarity and correctness are prioritized over speed or early generalization.
 
 ## Workspace Model (B1)
 
-The system uses a workspace-based publishing model.
+The target system uses a workspace-based publishing model.
 
 There are always:
 
@@ -76,7 +89,7 @@ There are always:
 
 All editing occurs in the draft workspace.
 
-Publishing performs:
+Target publish behavior performs:
 
 - A pointer flip (draft becomes published)
 - Creation of a new draft seeded from the newly published version
@@ -95,25 +108,24 @@ MenuVersion status:
 
 Preview is not a lifecycle state.
 
-Admin users may access a "View as public" preview that renders the draft workspace using public
-visibility rules.
+Admin preview is target behavior and is not implemented yet.
 
 ---
 
 ## Visibility vs Publish
 
-Visibility and publish state are independent.
+Visibility and publish state are independent in the target architecture.
 
 - `status` determines which workspace is public.
 - `isVisible` determines whether a category or item is shown.
 
-An item may be published but hidden.
+Item visibility is not implemented yet.
 
 ---
 
 ## Domain Read Context
 
-Domain reads are audience-aware.
+Domain reads are audience-aware in the target architecture.
 
 Possible audiences:
 
@@ -121,16 +133,16 @@ Possible audiences:
 - `adminPreview`
 - `adminEdit`
 
-Public reads operate only on the published workspace. Admin preview renders draft data using public
-visibility filters. Admin edit operates on the draft workspace and includes hidden content.
+Current implementation supports `adminEdit` draft reads. Public reads and admin preview are not
+implemented yet.
 
 ---
 
 # Money Handling
 
-Item prices are stored as integers in BRL centavos (`priceCents`).
+Item prices are planned to be stored as integers in BRL centavos (`priceCents`).
 
-Formatting is performed at the UI boundary.
+Item pricing and UI formatting are not implemented yet.
 
 ---
 
@@ -246,7 +258,11 @@ fast.
 
 ## Planned but Not Implemented Yet
 
-- Category and item domain models
+- ADR-011 Postgres singleton-DRAFT hardening
+- Category move up/down operation
+- Delete-empty category operation
+- Milestone 2 proof artifact
+- Item domain model
 - Publish flow (`DRAFT -> PUBLISHED -> new DRAFT`)
 - Public read path
 - Authentication boundary
@@ -275,6 +291,7 @@ Scope changes require explicit architectural decisions.
 - Phase B - Repository Initialization: Complete
 - Phase C - Milestone 0: Complete
 - Phase D - Milestone 1: Complete (2026-03-18)
+- Phase E - Milestone 2: Active
 
 Milestone 0 established the governed repository baseline and deterministic Prisma toolchain,
 verified migration pipeline, and fully reproducible clean-clone setup.
@@ -282,4 +299,6 @@ verified migration pipeline, and fully reproducible clean-clone setup.
 Milestone 1 added domain-level draft bootstrap and deterministic draft retrieval with explicit
 invariant enforcement.
 
-Current focus is Milestone 2 - Categories Ordered Within Draft.
+Milestone 2 has added category schema, repository boundary, ordering invariant enforcement, and
+draft category creation. Current focus is ADR-011 singleton-DRAFT hardening before the next category
+mutation slice.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Status: Active execution phase. Last reviewed: 2026-04-14.
+Status: Active execution phase. Last reviewed: 2026-05-29.
 
 This document defines the ordered progression of capability delivery. It translates milestone
 definitions into execution sequence and current focus.
@@ -11,8 +11,10 @@ Milestones define capability boundaries. This roadmap defines progression and ex
 
 # Roadmap Principles
 
-- Execution follows milestone order strictly.
-- No milestone work begins before the previous milestone is closed.
+- Execution follows milestone order for product capabilities.
+- No product capability work begins before its prerequisite milestone is closed.
+- Cross-cutting hardening may be inserted when implementation review exposes an unresolved invariant
+  or accepted ADR follow-up.
 - Architectural stability takes precedence over speed.
 - Scope expansion requires an ADR.
 
@@ -105,6 +107,8 @@ Deliverable (Satisfied):
 
 ## Milestone 2 - Categories in Draft
 
+Status: Active.
+
 Objective: Enable category management with strict ordering.
 
 Focus Areas:
@@ -112,6 +116,25 @@ Focus Areas:
 - Category model
 - Ordering invariants
 - Create / move / delete-empty operations
+
+Implemented so far:
+
+- Category schema linked to `MenuVersion`
+- Category domain model and repository boundary
+- Prisma-backed category repository adapter
+- Category ordering invariant checker
+- Draft category creation operation
+
+Remaining core work:
+
+- Move category up/down within draft workspace
+- Delete empty category and close ordering gap
+- Milestone 2 proof artifact
+
+Deferred hardening:
+
+- Concurrent category append protection
+- Category creation postcondition checks
 
 Deliverable:
 
@@ -173,11 +196,23 @@ Deliverable:
 
 Current Milestone: Milestone 2 - Categories in Draft
 
-Next Action:
+Current implementation state:
 
-- Define Category schema linked to MenuVersion
-- Introduce Category repository contract at domain boundary
-- Implement domain ordering invariant (0-based, contiguous, unique)
+- M2-01 through M2-04 are implemented.
+- M2-05 through M2-07 remain open.
+- ADR-011 records a Postgres singleton-DRAFT enforcement decision that must be implemented before
+  relying on the draft workspace invariant for broader mutation flows.
+
+Next Actions:
+
+1. Implement ADR-011 follow-ups:
+   - add Postgres partial unique index for singleton DRAFT
+   - add repository create-conflict readback
+   - verify deterministic bootstrap behavior
+2. Continue Milestone 2 core work with M2-05:
+   - move category up/down within draft workspace
+   - preserve 0-based, contiguous, unique category positions
+   - fail loudly on corrupted ordering
 
 ---
 

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -7,7 +7,7 @@ review and may require a new ADR.
 
 # Core Purpose
 
-Labareda Menu Manager is a single-restaurant administrative tool that enables:
+Labareda Menu Manager is scoped as a single-restaurant administrative tool that supports:
 
 - Draft editing of menu structure and items
 - Controlled publishing to a public menu
@@ -18,9 +18,35 @@ The system is intentionally constrained and does not aim to be a general restaur
 
 ---
 
+# Current Implementation Status
+
+The current implementation is an early domain and persistence foundation for this product scope.
+
+Implemented now:
+
+- `MenuVersion` persistence with DRAFT, PUBLISHED, and REPLACED statuses
+- Draft workspace domain behavior
+- Category persistence linked to `MenuVersion`
+- Category domain model and repository boundary
+- Category ordering invariant enforcement
+- Category creation in the draft workspace
+
+Not implemented yet:
+
+- Item model, pricing, ordering, or visibility behavior
+- Category update, move, or delete-empty operations
+- Publish flow
+- Public menu read behavior
+- Admin route handlers or UI workflows
+
+These omissions do not change the intended product scope; they mark the current implementation
+boundary.
+
+---
+
 # In-Scope
 
-The following capabilities are explicitly in scope:
+The following capabilities are explicitly in product scope:
 
 ## Menu Management
 

--- a/docs/planning/milestone-2/ISSUE_MAP.md
+++ b/docs/planning/milestone-2/ISSUE_MAP.md
@@ -3,7 +3,7 @@
 # Milestone 2 - Issue Map
 
 Status: Planning artifact. Purpose: Derive the issue sequence needed to close Milestone 2 -
-Categories Ordered Within Draft. Last reviewed: 2026-05-12.
+Categories Ordered Within Draft. Last reviewed: 2026-05-30.
 
 Milestone capability target:
 
@@ -21,9 +21,10 @@ domain layer:
 2. M2-02 - Category domain model + repository boundary
 3. M2-03 - Category ordering invariant checker
 4. M2-04 - Create category in draft workspace
-5. M2-05 - Move category up/down within draft workspace
-6. M2-06 - Delete empty category and close ordering gap
-7. M2-07 - Integration verification proof artifact
+5. M2-P01 - Implement Postgres singleton-DRAFT enforcement
+6. M2-05 - Move category up/down within draft workspace
+7. M2-06 - Delete empty category and close ordering gap
+8. M2-07 - Integration verification proof artifact
 
 ---
 
@@ -198,6 +199,33 @@ Out of scope:
 - Category reordering
 - UI and route handlers
 
+## M2-P01 - Implement Postgres singleton-DRAFT enforcement
+
+Problem type: invariant and persistence guardrail.
+
+Capability added:
+
+- Postgres prevents duplicate DRAFT workspaces and repository bootstrap handles the expected
+  concurrent create-conflict path deterministically.
+
+Success criteria:
+
+- Postgres migration adds partial unique index `MenuVersion_single_draft_key`
+- Index enforces uniqueness for `MenuVersion.status = 'DRAFT'`
+- `PrismaMenuVersionRepository.createDraft()` translates the expected unique-conflict path into a
+  read of the singleton DRAFT
+- Non-constraint failures still surface
+- Zero-DRAFT or multiple-DRAFT corruption during normal reads still fails loudly in the domain
+- Tests cover sequential bootstrap and create-conflict readback behavior
+
+Out of scope:
+
+- Category move/delete behavior
+- Category append concurrency hardening
+- Publish flow
+- Public read
+- UI and route handlers
+
 ## M2-05 - Move category up/down within draft workspace
 
 Problem type: transformation.
@@ -288,8 +316,10 @@ Out of scope:
 # What Is Allowed to Change
 
 - Prisma schema and migrations for category persistence
+- Prisma migration for the ADR-011 singleton-DRAFT Postgres guardrail
 - Domain category model, errors, repository contracts, and operations
 - Persistence adapter implementation for category repositories
+- Focused repository behavior for singleton-DRAFT create-conflict readback
 - DB-free domain tests for category behavior
 - A focused proof script for Milestone 2 closure
 - Documentation that records the actual capability and verification evidence
@@ -305,6 +335,8 @@ Out of scope:
 - No database access in domain tests
 - No item, publish, public-read, or authentication behavior in Milestone 2
 - No silent corruption repair outside explicit domain operations
+- M2-P01 may harden storage and repository behavior for singleton-DRAFT bootstrap, but it must not
+  change the domain invariant posture for corrupted non-empty workspace state
 
 ---
 

--- a/docs/planning/milestone-2/issues/M2-05-move-category-up-down-within-draft-workspace.md
+++ b/docs/planning/milestone-2/issues/M2-05-move-category-up-down-within-draft-workspace.md
@@ -1,0 +1,67 @@
+## [Feature] Move category up and down within draft workspace
+
+## Problem Statement
+
+Milestone 2 requires categories to be ordered within the draft workspace.
+
+The system needs a controlled move operation that changes a category by one position while
+preserving 0-based, contiguous, unique ordering.
+
+---
+
+## Why Now
+
+Once categories can be created with valid positions, the next required behavior is local reordering.
+
+The move operation must validate current state before mutation so it does not build on corrupted
+ordering.
+
+---
+
+## Scope
+
+In scope:
+
+- Add a domain operation for moving a draft category up or down by one position.
+- Validate current category order before mutation.
+- Swap with the adjacent category in the requested direction.
+- Choose and test boundary behavior for first/last category moves.
+- Write only affected category positions.
+- Add deterministic domain tests.
+
+Out of scope:
+
+- Arbitrary drag-and-drop repositioning
+- UI and route handlers
+- Item ordering
+- Publish behavior
+
+---
+
+## Acceptance Criteria
+
+- [ ] Operation validates current order before mutation.
+- [ ] Moving up swaps with the previous category.
+- [ ] Moving down swaps with the next category.
+- [ ] Boundary behavior is explicit and tested for first category moving up.
+- [ ] Boundary behavior is explicit and tested for last category moving down.
+- [ ] Operation writes only affected category positions.
+- [ ] Corrupted existing order prevents movement.
+
+---
+
+## Architectural Notes
+
+- Problem type: transformation
+- Boundary no-op vs domain failure must be chosen before implementation.
+- The domain owns the move rule; persistence only applies writes.
+- No UI behavior should define lifecycle semantics.
+
+---
+
+## References
+
+- Related ADR: ADR-012 - Category ordering field name is position
+- Related Milestone: Milestone 2 - Categories Ordered Within Draft
+- Related GitHub Issue: #91
+- Related Issue Map Entry: M2-05

--- a/docs/planning/milestone-2/issues/M2-06-delete-empty-category-and-close-ordering-gap.md
+++ b/docs/planning/milestone-2/issues/M2-06-delete-empty-category-and-close-ordering-gap.md
@@ -1,0 +1,69 @@
+## [Feature] Delete empty category and close ordering gap
+
+## Problem Statement
+
+Milestone 2 requires empty draft categories to be deletable without leaving ordering gaps.
+
+Deleting a category must preserve contiguous order and must not silently delete or orphan future
+item data.
+
+---
+
+## Why Now
+
+Create and move are not enough for category lifecycle. The milestone explicitly requires
+delete-empty-category behavior.
+
+This issue adds deletion while preserving the ordering invariant and keeping item-related behavior
+excluded.
+
+---
+
+## Scope
+
+In scope:
+
+- Add a domain operation for deleting an empty category from the draft workspace.
+- Validate current order before deletion.
+- Confirm the category belongs to the draft workspace.
+- Refuse to delete non-empty categories.
+- Delete the selected category.
+- Shift later categories down by one position.
+- Add deterministic domain tests.
+
+Out of scope:
+
+- Cascading item deletion
+- Item model implementation
+- UI and route handlers
+- Public read behavior
+
+---
+
+## Acceptance Criteria
+
+- [ ] Operation validates current order before deletion.
+- [ ] Operation confirms the category belongs to the draft workspace.
+- [ ] Operation refuses to delete non-empty categories explicitly.
+- [ ] Deleting the first category closes positions.
+- [ ] Deleting a middle category closes positions.
+- [ ] Deleting the last category leaves earlier positions unchanged.
+- [ ] Corrupted existing order prevents deletion.
+
+---
+
+## Architectural Notes
+
+- Problem type: lifecycle and state transition
+- Empty-category policy belongs in the domain layer.
+- Persistence adapters must not decide whether deletion is allowed.
+- Item behavior remains intentionally excluded from Milestone 2.
+
+---
+
+## References
+
+- Related ADR: ADR-012 - Category ordering field name is position
+- Related Milestone: Milestone 2 - Categories Ordered Within Draft
+- Related GitHub Issue: #92
+- Related Issue Map Entry: M2-06

--- a/docs/planning/milestone-2/issues/M2-07-integration-verification-and-milestone-2-proof.md
+++ b/docs/planning/milestone-2/issues/M2-07-integration-verification-and-milestone-2-proof.md
@@ -1,0 +1,74 @@
+## [Documentation] Milestone 2 integration verification proof artifact
+
+## Problem Statement
+
+Milestone 2 cannot close based on local confidence or partial implementation.
+
+The repository needs a reproducible proof artifact showing that categories can be created, moved,
+and deleted when empty while preserving the category ordering invariant.
+
+---
+
+## Why Now
+
+Milestones are capability boundaries. Closure requires demonstrable evidence, not just completed
+implementation tasks.
+
+This issue records the proof needed to close Milestone 2 and keeps the repository state aligned with
+governance docs.
+
+---
+
+## Scope
+
+In scope:
+
+- Add Milestone 2 proof documentation under `docs/planning/milestone-2/issues/**`.
+- Document the milestone capability boundary.
+- Document the category ordering invariant and failure surface.
+- Document required verification commands.
+- Include proof of domain unit tests, Prisma migration/reset health, and persistence-backed
+  create/move/delete-empty behavior.
+- Update `MILESTONES.md` and `docs/planning/milestone-2/ISSUE_MAP.md` only when closure is real.
+
+Out of scope:
+
+- Claiming closure before implementation and proof commands pass
+- Items
+- Publish flow
+- Public read
+- Authentication
+
+---
+
+## Acceptance Criteria
+
+- [ ] Proof artifact exists at
+      `docs/planning/milestone-2/issues/M2-07-integration-verification-and-milestone-2-proof.md`.
+- [ ] Artifact states the Milestone 2 capability boundary.
+- [ ] Artifact states the category ordering invariant.
+- [ ] Artifact documents explicit exclusions.
+- [ ] Artifact includes copy/paste verification commands.
+- [ ] Verification includes domain unit tests.
+- [ ] Verification includes Prisma migration/reset health.
+- [ ] Verification includes persistence-backed proof of create, move, and delete-empty behavior.
+- [ ] `MILESTONES.md` and the issue map are updated only after proof passes.
+
+---
+
+## Architectural Notes
+
+- Problem type: closure evidence
+- The proof must answer: what can the system reliably do now that it could not do before?
+- Expected capability: the domain layer can create, move, and delete empty categories within the
+  draft `MenuVersion` workspace while preserving 0-based, contiguous, unique category ordering per
+  version.
+- No ADR expected unless implementation introduces new cross-cutting constraints.
+
+---
+
+## References
+
+- Related Milestone: Milestone 2 - Categories Ordered Within Draft
+- Related GitHub Issue: #93
+- Related Issue Map Entry: M2-07

--- a/docs/planning/milestone-2/issues/M2-P01-implement-postgres-singleton-draft-enforcement.md
+++ b/docs/planning/milestone-2/issues/M2-P01-implement-postgres-singleton-draft-enforcement.md
@@ -1,0 +1,91 @@
+## [Feature] Implement Postgres singleton-DRAFT enforcement
+
+## Problem Statement
+
+ADR-011 records that the singleton DRAFT workspace invariant must be enforced in Postgres with a
+partial unique index and repository conflict readback.
+
+The current implementation enforces the single-DRAFT invariant in the domain layer, but the database
+does not yet prevent duplicate DRAFT rows and `PrismaMenuVersionRepository.createDraft()` does not
+yet reconcile create conflicts during empty-database bootstrap.
+
+---
+
+## Why This Matters Now
+
+Milestone 2 mutation flows depend on a trustworthy draft workspace.
+
+Before adding broader category mutation behavior, the system should close the storage-level gap for
+the existing draft invariant so category operations are not built on a partially enforced workspace
+foundation.
+
+---
+
+## Success Criteria
+
+- [ ] A Postgres migration adds a partial unique index for singleton DRAFT enforcement.
+- [ ] The index is named `MenuVersion_single_draft_key`.
+- [ ] The index enforces uniqueness for `MenuVersion.status = 'DRAFT'`.
+- [ ] `PrismaMenuVersionRepository.createDraft()` translates the expected create-conflict path into
+      a read of the singleton DRAFT.
+- [ ] Non-constraint failures still surface.
+- [ ] Zero-DRAFT or multiple-DRAFT corruption during normal reads still fails loudly in the domain.
+- [ ] Deterministic tests cover sequential bootstrap behavior.
+- [ ] Deterministic tests cover create-conflict readback behavior.
+- [ ] Verification passes through the repo quality gate.
+
+---
+
+## Scope & Constraints
+
+In scope:
+
+- Add the Postgres partial unique index required by ADR-011.
+- Implement repository create-conflict readback for bootstrap creation.
+- Add focused tests for bootstrap conflict behavior.
+- Keep the domain invariant posture unchanged.
+
+Out of scope:
+
+- Category move/delete behavior
+- Category append concurrency hardening
+- Publish flow
+- Public read behavior
+- UI and route handlers
+
+Constraints:
+
+- This issue must not silently repair non-empty corrupted workspace state.
+- The repository may reconcile only the expected create-conflict path during empty bootstrap.
+- Domain code must not import Prisma or database-specific error types.
+- Persistence remains responsible only for data access, mapping, and database-conflict translation.
+
+---
+
+## Architectural Notes
+
+Problem type: invariant and persistence guardrail.
+
+Required invariant:
+
+Exactly one DRAFT `MenuVersion` exists. The domain enforces this on reads, and Postgres must prevent
+duplicate DRAFT rows at the storage layer.
+
+Expected migration shape:
+
+```sql
+CREATE UNIQUE INDEX "MenuVersion_single_draft_key"
+ON "MenuVersion" ("status")
+WHERE "status" = 'DRAFT';
+```
+
+This issue implements ADR-011. It should run before M2-05 because category move/delete operations
+depend on the draft workspace invariant.
+
+---
+
+## References
+
+- Related ADR: ADR-011 - Postgres singleton-DRAFT enforcement model
+- Related Milestone: Milestone 2 - Categories Ordered Within Draft
+- Related Roadmap: Current Focus / ADR-011 follow-ups


### PR DESCRIPTION
## Summary

- records ADR-011 for Postgres singleton-DRAFT enforcement and ADR-012 for category `position` naming
- adds remaining Milestone 2 issue plans for singleton-DRAFT hardening, category move, delete-empty, and proof closure
- updates canonical governance docs to reflect current category implementation state and remaining exclusions

## Verification

- `npm run verify`

## Notes

This is documentation-only. It does not add Prisma migrations, implementation code, generated files, route handlers, UI, or milestone closure claims.